### PR TITLE
Add Github Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - "v**"
+  pull_request:
+
+# permissions:
+#   checks: write
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actionhippie/swap-space@v1
+        with:
+          size: 10G
+      # Rust setup
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          rustflags: "-Aunused_imports"
+          cache-workspaces: |
+            scryer -> target
+            scryer -> pkg
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
+      # Node setup
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+      - run: npm ci
+
+      # Build and test.
+      - name: Build wasm
+        run: npm run compile
+      - name: Build library
+        run: npm run build
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
Simple build/test CI workflow. A bit slow because it builds the wasm from scratch. It can probably be cached better in the future (based on the Scryer version etc.)