### PR TITLE
init automatically on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ npm install scryer
 ```
 
 ```typescript
-import { init, Prolog } from "scryer";
-
-await init();
+import { Prolog } from "scryer";
 
 const pl = new Prolog();
 const query = pl.query("X = 1 ; X = 2.");
@@ -24,8 +22,7 @@ For browsers, you can use [esm.sh](https://esm.sh) or other CDNs to import it di
 
 ```html
 <script type="module">
-	import { init, Prolog } from "https://esm.sh/scryer"; // ideally add version info to the URL, e.g. scryer@0.1.0
-	await init();
+	import { Prolog } from "https://esm.sh/scryer@0.5.0"; // make sure to use the latest version instead :-)
 	// query stuff
 </script>
 ```

--- a/src/prolog.ts
+++ b/src/prolog.ts
@@ -24,6 +24,9 @@ const initOnce = (async function init() {
 	await initScryer(module);
 })();
 
+await initOnce;
+
+/** @deprecated No longer necessary to call */
 export async function init() {
 	await initOnce;
 }

--- a/test.js
+++ b/test.js
@@ -2,7 +2,6 @@ import test from "node:test";
 import assert from "node:assert";
 
 import {
-	init,
 	Prolog,
 	Atom,
 	Compound,

--- a/test.js
+++ b/test.js
@@ -22,10 +22,6 @@ import {
 	isException,
 } from "./dist/scryer.js";
 
-await test("load", async (t) => {
-	await init();
-});
-
 test("query", async (t) => {
 	const pl = new Prolog();
 	const query = pl.query(`


### PR DESCRIPTION
This makes it so you don't need to call `init()` anymore. It's something I've wanted to do for a while in trealla-js, but IIRC it breaks compatibility with commonjs builds. Browsers have good support: https://caniuse.com/mdn-javascript_operators_await_top_level

Maybe it's time to pull the plug?