### PR TITLE
README with Updated Example and Development Setup Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,45 @@ import { init, Prolog } from "scryer";
 
 await init();
 
+const kb1 = `
+:- use_module(library(format)).
+:- use_module(library(clpz)).
+:- use_module(library(lists)).
+
+sudoku(Rows) :-
+length(Rows, 9), maplist(same_length(Rows), Rows),
+append(Rows, Vs), Vs ins 1..9,
+maplist(all_distinct, Rows),
+transpose(Rows, Columns),
+maplist(all_distinct, Columns),
+Rows = [As,Bs,Cs,Ds,Es,Fs,Gs,Hs,Is],
+blocks(As, Bs, Cs),
+blocks(Ds, Es, Fs),
+blocks(Gs, Hs, Is).
+
+blocks([], [], []).
+blocks([N1,N2,N3|Ns1], [N4,N5,N6|Ns2], [N7,N8,N9|Ns3]) :-
+all_distinct([N1,N2,N3,N4,N5,N6,N7,N8,N9]),
+blocks(Ns1, Ns2, Ns3).
+`;
+
+const kb2 = `
+problem(1, [[_,_,_,_,_,_,_,_,_],
+			[_,_,_,_,_,3,_,8,5],
+			[_,_,1,_,2,_,_,_,_],
+			[_,_,_,5,_,7,_,_,_],
+			[_,_,4,_,_,_,1,_,_],
+			[_,9,_,_,_,_,_,_,_],
+			[5,_,_,_,_,_,_,7,3],
+			[_,_,2,_,1,_,_,_,_],
+			[_,_,_,_,4,_,_,_,9]]).
+`;
+
 const pl = new Prolog();
-const query = pl.query("X = 1 ; X = 2.");
+pl.consultText(kb1);
+pl.consultText(kb2);
+
+const query = pl.query("problem(1, Rows), sudoku(Rows), maplist(portray_clause, Rows).");
 for (const answer of query) {
 	console.log(answer.bindings);
 }
@@ -28,6 +65,27 @@ For browsers, you can use [esm.sh](https://esm.sh) or other CDNs to import it di
 	await init();
 	// query stuff
 </script>
+```
+## Development
+
+After cloning the repository, make sure to initialize and update the submodules:
+
+```bash
+git submodule update --init --recursive
+```
+Alternatively, you can do this directly during the clone:
+
+```bash
+git clone --recurse-submodules -j8 <repository-url>
+```
+make sure to have [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) installed.
+
+Once the submodules are in place and wasm-pack is installed, run the following commands:
+
+```bash
+npm install
+npm run compile    # Installs the WASM package of Scryer Prolog and other dependencies
+npm run build      # Transpiles TypeScript code
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For browsers, you can use [esm.sh](https://esm.sh) or other CDNs to import it di
 ```
 ## Development
 
-After cloning the repository, make sure to initialize and update the submodules:
+After cloning the repository, make sure to initialize the submodules:
 
 ```bash
 git submodule update --init --recursive


### PR DESCRIPTION
This PR update the `README` with the following improvements:

- Modify the example to one that use a knowledge base, adapted from the outdated example in the [Scryer Prolog repository](https://github.com/mthom/scryer-prolog?tab=readme-ov-file#building-webassembly).
- Included a new "Development" section to guide contributors through setting up the project.

close #6