### PR TITLE
Add concurrency option for interrupting running queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ const pl = new Prolog();
 pl.consultText(kb1);
 pl.consultText(kb2);
 
-const query = pl.query("problem(1, Rows), sudoku(Rows), maplist(portray_clause, Rows).");
+const query = pl.query(
+	"problem(1, Rows), sudoku(Rows), maplist(portray_clause, Rows).",
+);
 for (const answer of query) {
 	console.log(answer.bindings);
 }
@@ -66,6 +68,7 @@ For browsers, you can use [esm.sh](https://esm.sh) or other CDNs to import it di
 	// query stuff
 </script>
 ```
+
 ## Development
 
 After cloning the repository, make sure to initialize the submodules:
@@ -73,11 +76,13 @@ After cloning the repository, make sure to initialize the submodules:
 ```bash
 git submodule update --init --recursive
 ```
+
 Alternatively, you can do this directly during the clone:
 
 ```bash
 git clone --recurse-submodules -j8 <repository-url>
 ```
+
 make sure to have [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) installed.
 
 Once the submodules are in place and wasm-pack is installed, run the following commands:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,34 @@ For browsers, you can use [esm.sh](https://esm.sh) or other CDNs to import it di
 </script>
 ```
 
+## Usage
+
+### Binding variables
+
+```typescript
+const answer = pl.queryOnce("X is Y * 2.", { bind: { Y: 21 } });
+console.log(answer.bindings); // { X: 42, Y: 21 }
+```
+
+### Template strings
+
+The `prolog` string template literal is an easy way to escape terms.
+Each `${value}` will be interpreted as a Prolog term.
+
+```typescript
+import { prolog, Variable } from "scryer";
+const answer = pl.queryOnce(
+	prolog`atom_chars(${new Variable("X")}, ${"Hello!"}).`,
+);
+console.log(answer.bindings); // { X: Atom('Hello!') }
+```
+
+### Events
+
+`Prolog` instances are subclasses of [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) and emit the following events:
+
+- `"ready"` -- fired when a query finishes and the interpreter is ready to execute a new query
+
 ## Development
 
 After cloning the repository, make sure to initialize the submodules:
@@ -91,26 +119,4 @@ Once the submodules are in place and wasm-pack is installed, run the following c
 npm install
 npm run compile    # Installs the WASM package of Scryer Prolog and other dependencies
 npm run build      # Transpiles TypeScript code
-```
-
-## Usage
-
-### Binding variables
-
-```typescript
-const answer = pl.queryOnce("X is Y * 2.", { bind: { Y: 21 } });
-console.log(answer.bindings); // { X: 42, Y: 21 }
-```
-
-### Template strings
-
-The `prolog` string template literal is an easy way to escape terms.
-Each `${value}` will be interpreted as a Prolog term.
-
-```typescript
-import { prolog, Variable } from "scryer";
-const answer = pl.queryOnce(
-	prolog`atom_chars(${new Variable("X")}, ${"Hello!"}).`,
-);
-console.log(answer.bindings); // { X: Atom('Hello!') }
 ```

--- a/test.js
+++ b/test.js
@@ -27,7 +27,11 @@ await test("load", async (t) => {
 });
 
 test("query", async (t) => {
+	let readies = 0;
 	const pl = new Prolog();
+	pl.addEventListener("ready", () => {
+		readies++;
+	});
 	const query = pl.query(`
 		  X = 1
 		; X = 9007199254740991  % max safe integer
@@ -59,10 +63,15 @@ test("query", async (t) => {
 	}
 	assert.deepEqual(i, want.length);
 	assert.ok(query.ok);
+	assert.deepEqual(readies, 1);
 });
 
 test("query failure", async (t) => {
+	let readies = 0;
 	const pl = new Prolog();
+	pl.addEventListener("ready", () => {
+		readies++;
+	});
 	let iter = 0;
 	const query = pl.query("false.");
 	assert.deepEqual(query.ok, undefined);
@@ -71,19 +80,26 @@ test("query failure", async (t) => {
 	}
 	assert.deepEqual(iter, 0);
 	assert.deepEqual(query.ok, false);
+	assert.deepEqual(readies, 1);
 
 	await t.test("queryOnce", (t) => {
 		const once = pl.queryOnce("false.");
 		assert.deepEqual(once, false);
+		assert.deepEqual(readies, 2);
 	});
 });
 
 test("queryOnce returns control", async (t) => {
+	let readies = 0;
 	const pl = new Prolog();
+	pl.addEventListener("ready", () => {
+		readies++;
+	});
 	for (let i = 0; i < 10; i++) {
 		const answer = pl.queryOnce("repeat, X = 1.");
 		assert.deepEqual(answer.bindings.X, 1);
 	}
+	assert.deepEqual(readies, 10);
 });
 
 test("query var binding", async (t) => {
@@ -101,7 +117,11 @@ test("query var binding", async (t) => {
 });
 
 test("query drop early", async (t) => {
+	let readies = 0;
 	const pl = new Prolog();
+	pl.addEventListener("ready", () => {
+		readies++;
+	});
 	const query = pl.query(`repeat, X = 1.`);
 	const want = [1, 1, 1];
 	let i = 0;
@@ -113,6 +133,7 @@ test("query drop early", async (t) => {
 	}
 	const extra = query.next();
 	assert.deepEqual(extra, { done: true, value: true });
+	assert.deepEqual(readies, 1);
 
 	await t.test("control returns to machine", (t) => {
 		const second = pl.query(`X = ok.`).next();
@@ -125,7 +146,11 @@ test("query drop early", async (t) => {
 
 test("concurrency", async (t) => {
 	await t.test("Prolog.busy", (t) => {
+		let readies = 0;
 		const pl = new Prolog();
+		pl.addEventListener("ready", () => {
+			readies++;
+		});
 		assert.ok(!pl.busy);
 		const query = pl.query(`X = 1 ; X = 2.`);
 		assert.ok(pl.busy);
@@ -134,6 +159,7 @@ test("concurrency", async (t) => {
 		query.next();
 		query.next(); // we need to advance twice here, unfortuantely
 		assert.ok(!pl.busy);
+		assert.deepEqual(readies, 1);
 	});
 
 	await t.test("interrupt", (t) => {


### PR DESCRIPTION
This is a potential implementation to address #7.

Adds:
- `Prolog.busy` to see if a query is currently active
- Option for interrupting old queries when running new ones

Questions:
- Is this a good idea?
- Should the interrupting behavior be the default? Or should we stick with the current default (trying to start a new query throws)?